### PR TITLE
Feature/oled display button control countdown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ pico_sdk_init()
 
 # Add executable. Default name is the project name, version 0.1
 
-add_executable(interactive-traffic-light interactive-traffic-light.c )
+add_executable(interactive-traffic-light interactive-traffic-light.c ssd1306.c)
 
 pico_set_program_name(interactive-traffic-light "interactive-traffic-light")
 pico_set_program_version(interactive-traffic-light "0.1")
@@ -50,7 +50,8 @@ target_link_libraries(interactive-traffic-light
         hardware_timer
         hardware_gpio
         hardware_pwm
-        hardware_clocks)
+        hardware_clocks
+        hardware_i2c)
 
 # Add the standard include files to the build
 target_include_directories(interactive-traffic-light PRIVATE

--- a/interactive-traffic-light.c
+++ b/interactive-traffic-light.c
@@ -12,7 +12,8 @@
 #define BUZZER 21
 #define BUZZER_FREQ 100
 
-typedef enum{
+typedef enum
+{
     RED,
     YELLOW,
     GREEN
@@ -25,7 +26,8 @@ struct light_state
 };
 
 volatile struct light_state current = {RED, 10000};
-volatile bool button_pressed = false;
+volatile bool button_A_pressed = false;
+volatile bool button_B_pressed = false;
 
 // Function prototypes
 void turn_on_red_signal();
@@ -34,7 +36,7 @@ void turn_on_green_signal();
 void turn_on_red_signal();
 void turn_on_yellow_signal();
 void setup();
-void BUTTON_A_interrupt_handler(uint gpio, uint32_t events);
+void button_interrupt_handler(uint gpio, uint32_t events);
 void change_state();
 void pwm_init_buzzer(uint pin);
 void beep(uint pin, uint32_t duration_ms);
@@ -42,20 +44,21 @@ int64_t beep_stop_callback(alarm_id_t id, void *user_data);
 bool state_controller();
 bool is_time_to_change();
 
-int64_t beep_stop_callback(alarm_id_t id, void *user_data) {
+int64_t beep_stop_callback(alarm_id_t id, void *user_data)
+{
     uint pin = (uintptr_t)user_data;
     pwm_set_gpio_level(pin, 0);
     return 0;
 }
 
-void beep(uint pin, uint32_t duration_ms) {
+void beep(uint pin, uint32_t duration_ms)
+{
     // Liga o buzzer com duty cycle de 50%
     pwm_set_gpio_level(pin, 2048);
 
     // Passa o pino como ponteiro para desligar depois
-    add_alarm_in_ms(duration_ms, beep_stop_callback, (void*)(uintptr_t)pin, false);
+    add_alarm_in_ms(duration_ms, beep_stop_callback, (void *)(uintptr_t)pin, false);
 }
-
 
 void pwm_init_buzzer(uint pin)
 {
@@ -67,55 +70,60 @@ void pwm_init_buzzer(uint pin)
     pwm_set_gpio_level(pin, 0);
 }
 
-bool state_controller(){
-    printf("Duration: %d seconds\n", current.duration/1000);
+bool state_controller()
+{
     current.duration -= 1000;
+    if (current.state == RED && current.duration <= 5000 && (button_A_pressed || button_B_pressed))
+        printf("Duration: %d seconds\n", current.duration / 1000);
 
-    if (button_pressed && current.state == RED && current.duration == 5000)
+    if ((button_A_pressed || button_B_pressed) && current.state == RED && current.duration == 5000)
     {
         beep(BUZZER, 5000);
-        button_pressed = false;
     }
-    if(is_time_to_change())
+    if (is_time_to_change())
         change_state();
     return true;
 }
 
 bool is_time_to_change()
 {
-    if (current.duration <= 0) return true;
+    if (current.duration <= 0)
+        return true;
     return false;
 }
 
-void change_state(){
+void change_state()
+{
     switch (current.state)
     {
-        case RED:
-            turn_on_green_signal();
-            current.state = GREEN;
-            current.duration = 10000;
-            break;
-        case GREEN:
-            turn_on_yellow_signal();
-            current.state = YELLOW;
-            current.duration = 3000;
-            break;
-        case YELLOW:
-            turn_on_red_signal();
-            current.state = RED;
-            current.duration = 10000;
-            break;
+    case RED:
+        button_A_pressed = false;
+        button_B_pressed = false;
+        turn_on_green_signal();
+        current.state = GREEN;
+        current.duration = 10000;
+        break;
+    case GREEN:
+        turn_on_yellow_signal();
+        current.state = YELLOW;
+        current.duration = 3000;
+        break;
+    case YELLOW:
+        turn_on_red_signal();
+        current.state = RED;
+        current.duration = 10000;
+        break;
     }
 }
 
-void BUTTON_A_interrupt_handler(uint gpio, uint32_t events)
+void button_interrupt_handler(uint gpio, uint32_t events)
 {
     if (events & GPIO_IRQ_EDGE_FALL)
     {
-        printf("Pedestrian BUTTON_A activated!\n");
+        printf("Pedestrian button %c activated!\n", gpio == BUTTON_A ? 'A' : 'B');
         current.duration = 1000;
         current.state = GREEN;
-        button_pressed = true;
+        button_A_pressed = true;
     }
 }
 
@@ -155,6 +163,11 @@ void setup()
     gpio_init(BUTTON_A);
     gpio_set_dir(BUTTON_A, GPIO_IN);
     gpio_pull_up(BUTTON_A);
+
+    gpio_init(BUTTON_B);
+    gpio_set_dir(BUTTON_B, GPIO_IN);
+    gpio_pull_up(BUTTON_B);
+
     pwm_init_buzzer(BUZZER);
     sleep_ms(2000);
     printf("Traffic Light System\n");
@@ -169,9 +182,9 @@ int main()
     struct repeating_timer buzzer_timer;
 
     add_repeating_timer_ms(-1000, state_controller, NULL, &timer);
-    gpio_set_irq_enabled_with_callback(BUTTON_A, GPIO_IRQ_EDGE_FALL, true, &BUTTON_A_interrupt_handler);
-    // add_alarm_in_ms(1000, state_controller, NULL, true);
-    
+    gpio_set_irq_enabled_with_callback(BUTTON_A, GPIO_IRQ_EDGE_FALL, true, &button_interrupt_handler);
+    gpio_set_irq_enabled(BUTTON_B, GPIO_IRQ_EDGE_FALL, true);
+
     while (true)
     {
         tight_loop_contents();

--- a/ssd1306.c
+++ b/ssd1306.c
@@ -1,0 +1,297 @@
+/*
+ *  Copyright (C) 2025 Lucas Jundi Hikazudani
+ *  Contact: lhjundi <at> outlook <dot> com
+ *
+ *  This file is part of Smart Bag (Transport of thermosensitive medicines).
+ *
+ *  Smart Bag is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Smart Bag is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Smart Bag.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+
+/**
+ * @file ssd1306.c
+ * @brief Implementação do driver para display OLED SSD1306
+ * 
+ * Este arquivo implementa as funções necessárias para controlar um display
+ * OLED baseado no controlador SSD1306 via I2C no Raspberry Pi Pico.
+ */
+
+#include "ssd1306.h"
+
+/**
+ * @brief Fonte de caracteres 5x7 pixels
+ * 
+ * Array que define os padrões de bits para caracteres ASCII de 32 a 126.
+ * Cada caractere é definido em uma matriz 5x7 pixels.
+ */
+static const uint8_t font5x7[][5] = {
+    // Definição dos caracteres ASCII de 32 (espaço) a 126 (~)
+    // Cada linha representa um caractere com 5 bytes, onde cada byte
+    // define uma coluna vertical de 8 pixels
+    {0x00,0x00,0x00,0x00,0x00}, // Espaço
+    {0x00,0x00,0x5F,0x00,0x00}, // !
+    {0x00,0x07,0x00,0x07,0x00}, // "
+    {0x14,0x7F,0x14,0x7F,0x14}, // #
+    {0x24,0x2A,0x7F,0x2A,0x12}, // $
+    {0x23,0x13,0x08,0x64,0x62}, // %
+    {0x36,0x49,0x55,0x22,0x50}, // &
+    {0x00,0x05,0x03,0x00,0x00}, // '
+    {0x00,0x1C,0x22,0x41,0x00}, // (
+    {0x00,0x41,0x22,0x1C,0x00}, // )
+    {0x14,0x08,0x3E,0x08,0x14}, // *
+    {0x08,0x08,0x3E,0x08,0x08}, // +
+    {0x00,0x50,0x30,0x00,0x00}, // ,
+    {0x08,0x08,0x08,0x08,0x08}, // -
+    {0x00,0x60,0x60,0x00,0x00}, // .
+    {0x20,0x10,0x08,0x04,0x02}, // /
+    {0x3E,0x51,0x49,0x45,0x3E}, // 0
+    {0x00,0x42,0x7F,0x40,0x00}, // 1
+    {0x72,0x49,0x49,0x49,0x46}, // 2
+    {0x21,0x41,0x49,0x4D,0x33}, // 3
+    {0x18,0x14,0x12,0x7F,0x10}, // 4
+    {0x27,0x45,0x45,0x45,0x39}, // 5
+    {0x3C,0x4A,0x49,0x49,0x31}, // 6
+    {0x41,0x21,0x11,0x09,0x07}, // 7
+    {0x36,0x49,0x49,0x49,0x36}, // 8
+    {0x46,0x49,0x49,0x29,0x1E}, // 9
+    {0x00,0x36,0x36,0x00,0x00}, // :
+    {0x00,0x56,0x36,0x00,0x00}, // ;
+    {0x08,0x14,0x22,0x41,0x00}, // <
+    {0x14,0x14,0x14,0x14,0x14}, // =
+    {0x00,0x41,0x22,0x14,0x08}, // >
+    {0x02,0x01,0x59,0x09,0x06}, // ?
+    {0x3E,0x41,0x5D,0x59,0x4E}, // @
+    {0x7C,0x12,0x11,0x12,0x7C}, // A
+    {0x7F,0x49,0x49,0x49,0x36}, // B
+    {0x3E,0x41,0x41,0x41,0x22}, // C
+    {0x7F,0x41,0x41,0x22,0x1C}, // D
+    {0x7F,0x49,0x49,0x49,0x41}, // E
+    {0x7F,0x09,0x09,0x09,0x01}, // F
+    {0x3E,0x41,0x49,0x49,0x7A}, // G
+    {0x7F,0x08,0x08,0x08,0x7F}, // H
+    {0x00,0x41,0x7F,0x41,0x00}, // I
+    {0x20,0x40,0x41,0x3F,0x01}, // J
+    {0x7F,0x08,0x14,0x22,0x41}, // K
+    {0x7F,0x40,0x40,0x40,0x40}, // L
+    {0x7F,0x02,0x0C,0x02,0x7F}, // M
+    {0x7F,0x04,0x08,0x10,0x7F}, // N
+    {0x3E,0x41,0x41,0x41,0x3E}, // O
+    {0x7F,0x09,0x09,0x09,0x06}, // P
+    {0x3E,0x41,0x51,0x21,0x5E}, // Q
+    {0x7F,0x09,0x19,0x29,0x46}, // R
+    {0x46,0x49,0x49,0x49,0x31}, // S
+    {0x01,0x01,0x7F,0x01,0x01}, // T
+    {0x3F,0x40,0x40,0x40,0x3F}, // U
+    {0x1F,0x20,0x40,0x20,0x1F}, // V
+    {0x3F,0x40,0x38,0x40,0x3F}, // W
+    {0x63,0x14,0x08,0x14,0x63}, // X
+    {0x07,0x08,0x70,0x08,0x07}, // Y
+    {0x61,0x51,0x49,0x45,0x43}, // Z
+    {0x00,0x7F,0x41,0x41,0x00}, // [
+    {0x02,0x04,0x08,0x10,0x20}, // Backslash
+    {0x00,0x41,0x41,0x7F,0x00}, // ]
+    {0x04,0x02,0x01,0x02,0x04}, // ^
+    {0x40,0x40,0x40,0x40,0x40}, // _
+    {0x00,0x01,0x02,0x04,0x00}, // `
+    {0x20,0x54,0x54,0x54,0x78}, // a
+    {0x7F,0x48,0x44,0x44,0x38}, // b
+    {0x38,0x44,0x44,0x44,0x20}, // c
+    {0x38,0x44,0x44,0x48,0x7F}, // d
+    {0x38,0x54,0x54,0x54,0x18}, // e
+    {0x08,0x7E,0x09,0x01,0x02}, // f
+    {0x0C,0x52,0x52,0x52,0x3E}, // g
+    {0x7F,0x08,0x04,0x04,0x78}, // h
+    {0x00,0x44,0x7D,0x40,0x00}, // i
+    {0x20,0x40,0x44,0x3D,0x00}, // j
+    {0x7F,0x10,0x28,0x44,0x00}, // k
+    {0x00,0x41,0x7F,0x40,0x00}, // l
+    {0x7C,0x04,0x18,0x04,0x78}, // m
+    {0x7C,0x08,0x04,0x04,0x78}, // n
+    {0x38,0x44,0x44,0x44,0x38}, // o
+    {0x7C,0x14,0x14,0x14,0x08}, // p
+    {0x08,0x14,0x14,0x18,0x7C}, // q
+    {0x7C,0x08,0x04,0x04,0x08}, // r
+    {0x48,0x54,0x54,0x54,0x20}, // s
+    {0x04,0x3F,0x44,0x40,0x20}, // t
+    {0x3C,0x40,0x40,0x20,0x7C}, // u
+    {0x1C,0x20,0x40,0x20,0x1C}, // v
+    {0x3C,0x40,0x30,0x40,0x3C}, // w
+    {0x44,0x28,0x10,0x28,0x44}, // x
+    {0x0C,0x50,0x50,0x50,0x3C}, // y
+    {0x44,0x64,0x54,0x4C,0x44}, // z
+    {0x00,0x08,0x36,0x41,0x00}, // {
+    {0x00,0x00,0x7F,0x00,0x00}, // |
+    {0x00,0x41,0x36,0x08,0x00}, // }
+    {0x08,0x08,0x2A,0x1C,0x08}, // ->
+    {0x08,0x1C,0x2A,0x08,0x08}  // <-
+};
+
+/**
+ * @brief Buffer de framebuffer do display
+ * 
+ * Armazena o estado de todos os pixels do display.
+ * O display é organizado em 8 páginas de 128 pixels de largura.
+ */
+static uint8_t buffer[SSD1306_WIDTH * SSD1306_HEIGHT / 8];
+
+/**
+ * @brief Envia um comando para o display
+ * 
+ * @param i2c Instância I2C a ser utilizada
+ * @param cmd Comando a ser enviado
+ */
+static void ssd1306_write_command(i2c_inst_t *i2c, uint8_t cmd) {
+    uint8_t data[2] = {0x00, cmd};  // 0x00 indica byte de comando
+    i2c_write_blocking(i2c, SSD1306_I2C_ADDR, data, 2, false);
+}
+
+/**
+ * @brief Envia dados para o display
+ * 
+ * @param i2c Instância I2C a ser utilizada
+ * @param data Ponteiro para os dados
+ * @param len Quantidade de bytes a serem enviados
+ */
+static void ssd1306_write_data(i2c_inst_t *i2c, uint8_t *data, size_t len) {
+    uint8_t buf[len + 1];
+    buf[0] = 0x40; // 0x40 indica byte de dados
+    memcpy(buf + 1, data, len);
+    i2c_write_blocking(i2c, SSD1306_I2C_ADDR, buf, len + 1, false);
+}
+
+/**
+ * @brief Inicializa o display OLED
+ * 
+ * Configura os registradores do controlador SSD1306 com os valores
+ * necessários para operação normal do display.
+ * 
+ * @param i2c Instância I2C a ser utilizada
+ */
+void ssd1306_init(i2c_inst_t *i2c) {
+    sleep_ms(100); // Aguarda estabilização do display
+
+    // Sequência de inicialização conforme datasheet
+    ssd1306_write_command(i2c, 0xAE); // Display OFF
+    ssd1306_write_command(i2c, 0x20); // Set Memory Addressing Mode
+    ssd1306_write_command(i2c, 0x00); // Horizontal Addressing Mode
+    ssd1306_write_command(i2c, 0xB0); // Set Page Start Address for Page Addressing Mode
+    ssd1306_write_command(i2c, 0xC8); // COM Output Scan Direction remapped mode
+    ssd1306_write_command(i2c, 0x00); // Set low column address
+    ssd1306_write_command(i2c, 0x10); // Set high column address
+    ssd1306_write_command(i2c, 0x40); // Set start line address
+    ssd1306_write_command(i2c, 0x81); // Set contrast control
+    ssd1306_write_command(i2c, 0xFF);
+    ssd1306_write_command(i2c, 0xA1); // Set segment re-map 0 to 127
+    ssd1306_write_command(i2c, 0xA6); // Set normal display
+    ssd1306_write_command(i2c, 0xA8); // Set multiplex ratio(1 to 64)
+    ssd1306_write_command(i2c, 0x3F); // 1/64 duty
+    ssd1306_write_command(i2c, 0xA4); // Output follows RAM content
+    ssd1306_write_command(i2c, 0xD3); // Set display offset
+    ssd1306_write_command(i2c, 0x00); // No offset
+    ssd1306_write_command(i2c, 0xD5); // Set display clock divide ratio/oscillator frequency
+    ssd1306_write_command(i2c, 0xF0); // Set divide ratio
+    ssd1306_write_command(i2c, 0xD9); // Set pre-charge period
+    ssd1306_write_command(i2c, 0x22);
+    ssd1306_write_command(i2c, 0xDA); // Set com pins hardware configuration
+    ssd1306_write_command(i2c, 0x12);
+    ssd1306_write_command(i2c, 0xDB); // Set vcomh
+    ssd1306_write_command(i2c, 0x20);
+    ssd1306_write_command(i2c, 0x8D); // Set DC-DC enable
+    ssd1306_write_command(i2c, 0x14);
+    ssd1306_write_command(i2c, 0xAF); // Turn on SSD1306 panel
+}
+
+/**
+ * @brief Limpa o buffer do display
+ * 
+ * Preenche o buffer com zeros, apagando todos os pixels
+ */
+void ssd1306_clear() {
+    memset(buffer, 0, sizeof(buffer));
+}
+
+/**
+ * @brief Atualiza o conteúdo do display
+ * 
+ * Envia o conteúdo do buffer para o display, página por página
+ * 
+ * @param i2c Instância I2C a ser utilizada
+ */
+void ssd1306_update(i2c_inst_t *i2c) {
+    for (uint8_t page = 0; page < 8; page++) {
+        // Configura endereço da página
+        ssd1306_write_command(i2c, 0xB0 + page);
+        ssd1306_write_command(i2c, 0x00);  // Coluna inicial baixa
+        ssd1306_write_command(i2c, 0x10);  // Coluna inicial alta
+
+        // Envia dados da página
+        ssd1306_write_data(i2c, &buffer[SSD1306_WIDTH * page], SSD1306_WIDTH);
+    }
+}
+
+/**
+ * @brief Define o estado de um pixel no buffer
+ * 
+ * @param x Coordenada X (0-127)
+ * @param y Coordenada Y (0-63)
+ * @param color true para pixel aceso, false para apagado
+ */
+void ssd1306_draw_pixel(int x, int y, bool color) {
+    // Verifica limites
+    if (x < 0 || x >= SSD1306_WIDTH || y < 0 || y >= SSD1306_HEIGHT)
+        return;
+
+    // Calcula posição no buffer e bit correspondente
+    if (color)
+        buffer[x + (y / 8) * SSD1306_WIDTH] |= (1 << (y % 8));
+    else
+        buffer[x + (y / 8) * SSD1306_WIDTH] &= ~(1 << (y % 8));
+}
+
+/**
+ * @brief Desenha um caractere no display
+ * 
+ * @param x Coordenada X inicial
+ * @param y Coordenada Y inicial
+ * @param c Caractere a ser desenhado (ASCII 32-126)
+ * @param color true para pixels acesos, false para apagados
+ */
+void ssd1306_draw_char(int x, int y, char c, bool color) {
+    if (c < 32 || c > 126)
+        return;
+
+    // Desenha cada coluna do caractere
+    for (int i = 0; i < 5; i++) {
+        uint8_t line = font5x7[c - 32][i];
+        for (int j = 0; j < 8; j++) {
+            ssd1306_draw_pixel(x + i, y + j, (line & 0x01) ? color : !color);
+            line >>= 1;
+        }
+    }
+}
+
+/**
+ * @brief Desenha uma string no display
+ * 
+ * @param x Coordenada X inicial
+ * @param y Coordenada Y inicial
+ * @param str String a ser desenhada
+ * @param color true para pixels acesos, false para apagados
+ */
+void ssd1306_draw_string(int x, int y, const char *str, bool color) {
+    while (*str) {
+        ssd1306_draw_char(x, y, *str++, color);
+        x += 6; // Avançar 6 pixels (5 de largura + 1 de espaço)
+    }
+}

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (C) 2025 Lucas Jundi Hikazudani
+ *  Contact: lhjundi <at> outlook <dot> com
+ *
+ *  This file is part of Smart Bag (Transport of thermosensitive medicines).
+ *
+ *  Smart Bag is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Smart Bag is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Smart Bag.  If not, see <https://www.gnu.org/licenses/>
+ */
+
+
+/**
+ * @file ssd1306.h
+ * @brief Interface do driver para display OLED SSD1306
+ * 
+ * Este arquivo define as constantes e funções públicas para controle
+ * de displays OLED baseados no controlador SSD1306 via I2C usando
+ * o Raspberry Pi Pico.
+ */
+
+ #ifndef SSD1306_H
+ #define SSD1306_H
+ 
+ #include "pico/stdlib.h"         // Funções básicas do Raspberry Pi Pico
+ #include "hardware/i2c.h"        // Funções de controle do I2C
+ #include <string.h>             // Para memcpy e memset
+ 
+ /**
+  * @brief Definições básicas do display OLED SSD1306
+  */
+ #define SSD1306_I2C_ADDR 0x3C   // Endereço I2C padrão do display
+ #define SSD1306_WIDTH 128       // Largura do display em pixels
+ #define SSD1306_HEIGHT 64       // Altura do display em pixels
+ 
+ /**
+  * @brief Inicializa o display OLED
+  * 
+  * Configura o display com as definições padrão e o prepara para uso.
+  * Deve ser chamada antes de qualquer outra função do display.
+  * 
+  * @param i2c Ponteiro para a instância I2C a ser utilizada
+  */
+ void ssd1306_init(i2c_inst_t *i2c);
+ 
+ /**
+  * @brief Limpa todo o conteúdo do display
+  * 
+  * Apaga todos os pixels do buffer interno.
+  * Para aplicar a mudança, é necessário chamar ssd1306_update().
+  */
+ void ssd1306_clear();
+ 
+ /**
+  * @brief Atualiza o conteúdo do display
+  * 
+  * Envia o conteúdo do buffer interno para o display.
+  * Deve ser chamada após modificações no buffer para que
+  * as alterações sejam visíveis.
+  * 
+  * @param i2c Ponteiro para a instância I2C a ser utilizada
+  */
+ void ssd1306_update(i2c_inst_t *i2c);
+ 
+ /**
+  * @brief Define o estado de um pixel específico
+  * 
+  * @param x Coordenada X do pixel (0 a 127)
+  * @param y Coordenada Y do pixel (0 a 63)
+  * @param color true para acender o pixel, false para apagar
+  * 
+  * @note As coordenadas são verificadas para garantir que estejam
+  * dentro dos limites do display. Coordenadas inválidas são ignoradas.
+  */
+ void ssd1306_draw_pixel(int x, int y, bool color);
+ 
+ /**
+  * @brief Desenha um caractere ASCII no display
+  * 
+  * Utiliza uma fonte 5x7 pixels para desenhar caracteres.
+  * 
+  * @param x Coordenada X inicial do caractere
+  * @param y Coordenada Y inicial do caractere
+  * @param c Caractere ASCII a ser desenhado (32-126)
+  * @param color true para caractere aceso em fundo apagado,
+  *              false para caractere apagado em fundo aceso
+  * 
+  * @note Caracteres fora do intervalo ASCII 32-126 são ignorados
+  */
+ void ssd1306_draw_char(int x, int y, char c, bool color);
+ 
+ /**
+  * @brief Desenha uma string de texto no display
+  * 
+  * Desenha uma sequência de caracteres, começando na posição especificada.
+  * Cada caractere ocupa 6 pixels de largura (5 + 1 de espaço).
+  * 
+  * @param x Coordenada X inicial da string
+  * @param y Coordenada Y inicial da string
+  * @param str Ponteiro para a string a ser desenhada
+  * @param color true para texto aceso em fundo apagado,
+  *              false para texto apagado em fundo aceso
+  * 
+  * @note A string deve ser terminada em nulo.
+  *       O texto continua até encontrar o final da string ou
+  *       atingir o limite direito do display.
+  */
+ void ssd1306_draw_string(int x, int y, const char *str, bool color);
+ 
+ #endif // SSD1306_H


### PR DESCRIPTION
This pull request introduces a more advanced version of the pedestrian traffic light system for the Raspberry Pi Pico. It adds support for user interaction via buttons and visual feedback through an OLED display, along with an integrated buzzer for auditory signaling.
Key Features

    OLED Display Support (SSD1306 via I2C):
    Displays current traffic light state, pedestrian status ("Walk!" / "Wait"), and countdown timer.

    Button Integration:
    Two buttons (A and B) allow pedestrians to request crossing. State transitions are updated accordingly.

    Buzzer Feedback:
    A PWM-controlled buzzer is used to provide audio cues during state changes.

    Improved State Management:
    Uses a structured state_t enum and a traffic_light_t struct to manage state, GPIO, and timing data cleanly.

    Interrupt-Driven Input Handling:
    Button presses are handled using GPIO interrupts, ensuring responsive interaction without blocking the main loop.